### PR TITLE
이전 충돌 흔적(main.jsp) 정리 및 IDE 관련 gitignore 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,11 @@ pom.xml
 
 # 기타
 .vscode/
+
+# IntelliJ 관련
+.idea/
+*.iml
+out/
+
+# Smart Tomcat 로컬 설정 제외
+.smarttomcat/

--- a/src/main/webapp/WEB-INF/views/common/main.jsp
+++ b/src/main/webapp/WEB-INF/views/common/main.jsp
@@ -7,17 +7,8 @@
 <head>
 <meta charset="UTF-8">
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<title>이루미 메인154321</title>
-=======
-<title>irumi!</title>
->>>>>>> 0028203c2fcc2f3e0d632eb9678fbe0460419967
-=======
+<title>이루미 메인화면 </title>
 
-<title>이루미 메인15</title>
-
->>>>>>> branch 'dntkdgh935-committest' of https://github.com/jongjerry123/irumi.git
 <style>
 body {
 	background-color: #111;


### PR DESCRIPTION
### 작업 내용:
- 이전 merge 과정에서 남은 충돌 마커 텍스트 삭제하여 코드 정리
- IntelliJ IDEA와 Smart Tomcat에서 자동 생성되는 설정 파일들을 `.gitignore`에 추가해 불필요한 파일이 git에 올라가지 않도록 방지

### 변경사항:
- 충돌 텍스트 정리 (main.jsp 등)
- `.gitignore`에 아래 내용 추가:
  - `.idea/`
  - `out/`
  - `.smarttomcat/`
  - IDE 관련 설정 파일 제외 처리
