### PR TITLE
Seonbin 0424 chatbot backend structuring

### DIFF
--- a/src/main/java/com/project/irumi/chatbot/context/ConvSession.java
+++ b/src/main/java/com/project/irumi/chatbot/context/ConvSession.java
@@ -6,11 +6,13 @@ import java.util.UUID;
 
 public class ConvSession {
 	private final String convId = UUID.randomUUID().toString();
-    private final String topic;
+	private final String topic;          // 대화 주제: job / spec / act / schedule
+    private String subtopicId = null;    // 서브 주제 ID (직무 ID or 스펙 ID 등)
     private String userId;
     private final List<String> contextHistory = new ArrayList<>();
 
     public ConvSession(String topic, String userId) {
+    	// 현재는 subtopic이 세션 중에 변경 가능한 주제인듯?
         this.topic = topic;
         this.userId = userId;
     }
@@ -37,6 +39,14 @@ public class ConvSession {
 
 	public void setUserId(String userId) {
 		this.userId = userId;
+	}
+
+	public String getSubtopicId() {
+		return subtopicId;
+	}
+
+	public void setSubtopicId(String subtopicId) {
+		this.subtopicId = subtopicId;
 	}
 
 }

--- a/src/main/java/com/project/irumi/chatbot/context/ConvSessionManager.java
+++ b/src/main/java/com/project/irumi/chatbot/context/ConvSessionManager.java
@@ -5,6 +5,12 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.stereotype.Component;
 
+/* 
+한 유저는 항상 하나의 세션만 가질 수 있다
+다른 탭으로 넘어가면 기존 세션은 삭제되고 새로 시작된다
+서버는 항상 로그인 유저의 userId를 알고 있다
+ */
+
 @Component
 public class ConvSessionManager {
 
@@ -12,6 +18,7 @@ public class ConvSessionManager {
 
     // 새 주제 시작 → 기존 세션 종료 후 새로 생성
     public ConvSession createNewSession(String userId, String topic) {
+    	sessionMap.remove(userId);
         ConvSession session = new ConvSession(userId, topic);
         sessionMap.put(userId, session);
         return session;

--- a/src/main/java/com/project/irumi/chatbot/controller/ChatbotController.java
+++ b/src/main/java/com/project/irumi/chatbot/controller/ChatbotController.java
@@ -1,6 +1,8 @@
 package com.project.irumi.chatbot.controller;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +18,7 @@ import com.project.irumi.chatbot.manager.ActChatManager;
 import com.project.irumi.chatbot.manager.JobChatManager;
 import com.project.irumi.chatbot.manager.SpecChatManager;
 import com.project.irumi.chatbot.manager.SsChatManager;
+import com.project.irumi.chatbot.model.dto.CareerItemDto;
 import com.project.irumi.chatbot.model.dto.ChatbotResponseDto;
 
 import jakarta.servlet.http.HttpSession;
@@ -60,7 +63,9 @@ public class ChatbotController {
 	// 세션매니저 관리 시작 (tab 유형에 따라 session 정보 저장)
 	@RequestMapping(value = "startChatSession.do", method = RequestMethod.POST)
 	@ResponseBody
-	public Map<String, String> startChatSession(@RequestParam("topic") String topic, HttpSession loginSession) {
+	public Map<String, String> startChatSession(
+			@RequestParam("topic") String topic, 
+			HttpSession loginSession) {
 
 		String userId = (String) loginSession.getAttribute("userId");
 		ConvSession session = convManager.createNewSession(userId, topic);
@@ -75,11 +80,14 @@ public class ChatbotController {
 	// 대화 시작하고 서브 토픽 설정 클릭 ===========================
 	@RequestMapping(value = "setConvSubTopic.do", method = RequestMethod.POST)
 	@ResponseBody
-	public ChatbotResponseDto setConvSubTopic(@RequestParam("userChoice") String userChoice,
-			@RequestParam("convId") String convId
+	public ChatbotResponseDto setConvSubTopic(
+			@RequestParam("userChoice") String userChoice,
+			@RequestParam("convId") String convId,
+			HttpSession loginSession
 	/* HttpSession loginSession */
 	) {
-		ConvSession session = convManager.getSession(convId);
+		String userId = (String) loginSession.getAttribute("userId");
+		ConvSession session = convManager.getSession(userId);
 		String topic = session.getTopic();
 
 		ChatbotResponseDto responseDto;
@@ -111,9 +119,11 @@ public class ChatbotController {
 	// 세션 정보에 따라 매니저 서비스 호출
 	@RequestMapping(value = "sendMessageToChatbot.do", method = RequestMethod.POST)
 	@ResponseBody
-	public ChatbotResponseDto sendMessageToChatbot(@RequestParam("convId") String convId,
+	public ChatbotResponseDto sendMessageToChatbot(
+			HttpSession loginSession,
 			@RequestParam("userMsg") String userMsg) {
-		ConvSession session = convManager.getSession(convId);
+		String userId = (String) loginSession.getAttribute("userId");
+		ConvSession session = convManager.getSession(userId);
 		String topic = session.getTopic();
 
 		ChatbotResponseDto responseDto;
@@ -143,11 +153,13 @@ public class ChatbotController {
 	// 유저가 챗봇이 준 옵션 중 선택 후 제출한 경우 ===========================
 	@RequestMapping(value = "submitChatbotOption.do", method = RequestMethod.POST)
 	@ResponseBody
-	public ChatbotResponseDto submitChatbotOption(@RequestParam("userChoice") String userChoice,
-			@RequestParam("convId") String convId
+	public ChatbotResponseDto submitChatbotOption(
+			@RequestParam("userChoice") String userChoice,
+			HttpSession loginSession
 	/* HttpSession loginSession */
 	) {
-		ConvSession session = convManager.getSession(convId);
+		String userId = (String) loginSession.getAttribute("userId");
+		ConvSession session = convManager.getSession(userId);
 		String topic = session.getTopic();
 
 		ChatbotResponseDto responseDto;
@@ -174,5 +186,55 @@ public class ChatbotController {
 
 		return responseDto;
 	}
+
+	// 메소드 추가 =====================================================
+	// 사용자가 직접 직무/ 스펙/ 일정/ 활동 입력하고 추가 버튼 누르는 경우
+	//1.  Dashboard Service(?) 사용해 사용자 career plan에 저장
+	// 2. Job, Spec, Ss, Activity Service로 각각의 테이블에 저장
+	//-- > 입력된 정보 다시 우측 사이드바에 받아오는 메소드 필요 
+	@RequestMapping(value = "insertCareerItem.do", 
+			method = RequestMethod.POST)
+	@ResponseBody
+	public CareerItemDto insertCareerItem(@RequestParam("itemId") String itemId,
+	                                           HttpSession session) {
+	    String userId = (String) session.getAttribute("userId");
+	    ConvSession convSession = convManager.getSession(userId);
+	    String topic = convSession.getTopic();
+	    
+	    //아래 토픽에 따라 manage, 
+	    CareerItemDto insertedItem = new CareerItemDto();
+
+	    switch (topic) {
+	        case "job":
+	          //  jobService.insertJob(insertedItem???); <-- job service 연계 필요
+	            break;
+
+	        case "spec":
+//	            String jobIdForSpec = convSession.getSubtopicId(); // 직무 ID
+//	            specService.insertSpec(insertedItem );
+
+	            break;
+
+	        case "act":
+//	          //actService.insertAct(Inserted);
+	            break;
+
+	        case "ss":
+	            break;
+
+	        default:
+	            return null;
+	    }
+	    return insertedItem;
+	 
+	}
+
+
+	
+	
+	
+	// 메소드 추가 =====================================================
+	// 사용자가 우측 사이드바에서 스펙/ 일정/ 활동.. 삭제하는 경우 Dashboard Service 사용
+		
 
 }

--- a/src/main/java/com/project/irumi/chatbot/manager/ActChatManager.java
+++ b/src/main/java/com/project/irumi/chatbot/manager/ActChatManager.java
@@ -19,5 +19,10 @@ public class ActChatManager {
 		return null;
 	}
 
+	public ChatbotResponseDto setConvSubTopic(ConvSession session, String userChoice) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
 
 }

--- a/src/main/java/com/project/irumi/chatbot/manager/JobChatManager.java
+++ b/src/main/java/com/project/irumi/chatbot/manager/JobChatManager.java
@@ -18,4 +18,9 @@ public class JobChatManager {
 		return null;
 	}
 
+	public ChatbotResponseDto setConvSubTopic(ConvSession session, String userChoice) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
 }

--- a/src/main/java/com/project/irumi/chatbot/manager/SpecChatManager.java
+++ b/src/main/java/com/project/irumi/chatbot/manager/SpecChatManager.java
@@ -18,4 +18,9 @@ public class SpecChatManager {
 		return null;
 	}
 
+	public ChatbotResponseDto setConvSubTopic(ConvSession session, String userChoice) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
 }

--- a/src/main/java/com/project/irumi/chatbot/manager/SsChatManager.java
+++ b/src/main/java/com/project/irumi/chatbot/manager/SsChatManager.java
@@ -18,4 +18,9 @@ public class SsChatManager {
 		return null;
 	}
 
+	public ChatbotResponseDto setConvSubTopic(ConvSession session, String userChoice) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
 }

--- a/src/main/java/com/project/irumi/chatbot/model/dto/CareerItemDto.java
+++ b/src/main/java/com/project/irumi/chatbot/model/dto/CareerItemDto.java
@@ -1,0 +1,38 @@
+package com.project.irumi.chatbot.model.dto;
+
+
+/*
+ * 
+다양한 타입(job, spec, act, ss)을 하나의 형태로 묶어서 프론트에 전달
+프론트에서는 title, content, type만 있으면 어떤 항목이든 UI에 표현 가능
+서버에서는 topic에 따라 CareerItemDto로 추상화해서 응답
+ * 
+ */
+public class CareerItemDto {
+	 private String itemId;     // jobId, specId, actId, ssId 등 (선택적으로 사용)
+	    private String title;      // 화면에 표시할 이름
+	    private String content;    // 상세 내용, 설명 등
+	    private String type;       // "job", "spec", "act", "ss"
+
+	    public CareerItemDto() {}
+
+	    public CareerItemDto(String itemId, String title, String content, String type) {
+	        this.itemId = itemId;
+	        this.title = title;
+	        this.content = content;
+	        this.type = type;
+	    }
+
+	    // Getter & Setter
+	    public String getItemId() { return itemId; }
+	    public void setItemId(String itemId) { this.itemId = itemId; }
+
+	    public String getTitle() { return title; }
+	    public void setTitle(String title) { this.title = title; }
+
+	    public String getContent() { return content; }
+	    public void setContent(String content) { this.content = content; }
+
+	    public String getType() { return type; }
+	    public void setType(String type) { this.type = type; }
+}


### PR DESCRIPTION
* 세션관리방식 정리, 챗봇페이지 컨트롤러 메소드 추가
* 각종 dto 추가

[세션 관리]
- 로그인 세션(HttpSession)에서 userId를 기준으로 ConvSession을 단일 생성 및 관리
- ConvSessionManager는 Map<userId, ConvSession> 형태로 세션 저장
- 한 유저당 하나의 ConvSession만 유지하며, 새로운 주제가 시작되면 기존 세션 삭제
- 컨트롤러에서는 convId가 아닌 userId를 기준으로 세션 조회 및 상태 유지

[메소드 추가]
- 우측 사이드바에서 사용자가 직접 아이템 입력 + 추가하는 경우
- 우측 사이드바에서 사용자가 직접 아이템 삭제 클릭하는 경우

해야 할 것
* 챗봇페이지에 각종 확인버튼 추가(확인후)
* job, spec, .. service 및 관련 클래스 구현 필요
* careerplan 클래스 구현 필요
* 새로운 컨트롤러 메세지 -> url mapping에 추가하기